### PR TITLE
Set logging level of Lambdas to INFO

### DIFF
--- a/message_status_handler/scheduled_lambda_function.py
+++ b/message_status_handler/scheduled_lambda_function.py
@@ -1,11 +1,14 @@
 import comms_management
 import environment
 import json
-import logging
+import logging as pylogging
+import os
 import batch_fetcher
 import message_status_recorder
 from typing import Dict, Any
 
+logging = pylogging.getLogger()
+logging.setLevel(os.getenv("LOG_LEVEL", "INFO"))
 
 
 def lambda_handler(_event: Any, _context: Any) -> Dict[str, Any]:


### PR DESCRIPTION
AWS Lambdas are preconfigured using log level WARN, but we need some tracing at log level INFO. 
We can alter this by setting the `LOG_LEVEL` env var.