### PR TITLE
Replace /api path prefix

### DIFF
--- a/batch_notification_processor/communication_management.py
+++ b/batch_notification_processor/communication_management.py
@@ -35,7 +35,7 @@ class CommunicationManagement:
             "authorization": f"Bearer {access_token.get_token()}"
         }
 
-        url = f"{self.base_url}/api/message/batch"
+        url = f"{self.base_url}/message/batch"
 
         response = requests.post(
             url,

--- a/message_status_handler/comms_management.py
+++ b/message_status_handler/comms_management.py
@@ -5,7 +5,7 @@ import logging
 
 def get_read_messages(batch_reference: str) -> dict:
     response = requests.get(
-        f"{os.getenv('COMMGT_BASE_URL')}/api/statuses",
+        f"{os.getenv('COMMGT_BASE_URL')}/statuses",
         headers={"x-api-key": os.getenv("API_KEY")},
         params={"batchReference": batch_reference, "channel": "nhsapp", "supplierStatus": "read"},
         timeout=10
@@ -16,7 +16,7 @@ def get_read_messages(batch_reference: str) -> dict:
 
     logging.error("Failed to fetch messages that have been read: %s ", response.text)
     return {
-        "status": "error", 
+        "status": "error",
         "message": f"Failed to fetch messages that have been read: {response.text}",
         "data": [],
     }

--- a/tests/end_to_end/communication_management_api_stub/app.py
+++ b/tests/end_to_end/communication_management_api_stub/app.py
@@ -12,7 +12,7 @@ dotenv.load_dotenv()
 request_cache = {}
 
 
-@app.route('/api/message/batch', methods=['POST'])
+@app.route('/message/batch', methods=['POST'])
 def message_batches():
     json_data = default_response_data() | request.json
     batch_reference = json_data["data"]["attributes"]["messageBatchReference"]
@@ -40,7 +40,7 @@ def message_batches():
     }), 201
 
 
-@app.route('/api/statuses', methods=['GET'])
+@app.route('/statuses', methods=['GET'])
 def statuses():
     batch_reference = request.args.get("batchReference")
     status = request.args.get("supplierStatus")

--- a/tests/integration/test_batch_notification_processor_updates_message_queue.py
+++ b/tests/integration/test_batch_notification_processor_updates_message_queue.py
@@ -25,7 +25,7 @@ def test_batch_notification_processor_updates_message_queue(
 
     with requests_mock.Mocker() as rm:
         rm.post(
-            f"{os.getenv('COMMGT_BASE_URL')}/api/message/batch",
+            f"{os.getenv('COMMGT_BASE_URL')}/message/batch",
             status_code=201,
             json={"data": {"id": "batch_id"}},
         )
@@ -55,7 +55,7 @@ def test_batch_notification_processor_payload(
 
     with requests_mock.Mocker() as rm:
         adapter = rm.post(
-            f"{os.getenv('COMMGT_BASE_URL')}/api/message/batch",
+            f"{os.getenv('COMMGT_BASE_URL')}/message/batch",
             status_code=201,
             json={"data": {"id": "batch_id"}},
         )

--- a/tests/integration/test_message_status_handler_updates_statuses.py
+++ b/tests/integration/test_message_status_handler_updates_statuses.py
@@ -14,7 +14,7 @@ def test_message_status_handler_updates_message_status(batch_id, recipient_data,
 
     with requests_mock.Mocker() as rm:
         rm.get(
-            f"{os.getenv('COMMGT_BASE_URL')}/api/statuses",
+            f"{os.getenv('COMMGT_BASE_URL')}/statuses",
             status_code=201,
             json={
                 'status': 'success',

--- a/tests/unit/batch_notification_processor/test_communication_management.py
+++ b/tests/unit/batch_notification_processor/test_communication_management.py
@@ -19,7 +19,7 @@ class TestCommunicationManagement:
 
         with requests_mock.Mocker() as rm:
             adapter = rm.post(
-                "http://example.com/api/message/batch",
+                "http://example.com/message/batch",
                 status_code=201,
                 json={"data": {"id": "batch_id"}},
             )
@@ -32,7 +32,7 @@ class TestCommunicationManagement:
                     Recipient(("1111111111", "message_reference_1", "requested")),
                 ]
             )
-            assert adapter.last_request.url == "http://example.com/api/message/batch"
+            assert adapter.last_request.url == "http://example.com/message/batch"
             assert adapter.last_request.headers["x-api-key"] == "api_key"
             assert adapter.last_request.headers["authorization"] == "Bearer access_token"
             assert adapter.last_request.json() == {

--- a/tests/unit/message_status_handler/test_comms_management.py
+++ b/tests/unit/message_status_handler/test_comms_management.py
@@ -7,7 +7,7 @@ def test_get_read_messages(monkeypatch):
 
     with requests_mock.Mocker() as rm:
         adapter = rm.get(
-            "http://example.com/api/statuses",
+            "http://example.com/statuses",
             status_code=201,
             json={
                 'status': 'success',
@@ -46,7 +46,7 @@ def test_get_read_messages_no_data(monkeypatch):
 
     with requests_mock.Mocker() as rm:
         rm.get(
-            "http://example.com/api/statuses",
+            "http://example.com/statuses",
             status_code=201,
             json={
                 'status': 'success',
@@ -65,7 +65,7 @@ def test_get_read_messages_exception(monkeypatch):
 
     with requests_mock.Mocker() as rm:
         rm.get(
-            "http://example.com/api/statuses",
+            "http://example.com/statuses",
             status_code=500,
             json={
                 'status': 'error',


### PR DESCRIPTION
The Azure public API gateway does not export the `/api` path prefix for the Communication Management API as it creates a bespoke path fragment based on environment region and function name eg. `int-uks-notify`