### PR TITLE
Use custom security group and filter out public subnets

### DIFF
--- a/terraform/modules/network/main.tf
+++ b/terraform/modules/network/main.tf
@@ -7,9 +7,13 @@ data "aws_subnets" "private" {
     name   = "vpc-id"
     values = [data.aws_vpc.selected.id]
   }
+
+  tags = {
+    "Name" = "*private*"
+  }
 }
 
 data "aws_security_group" "lambda" {
-  name = "bcss-oracle-bcss-dev-sec-grp"
+  name = "bcss-notify-lambdas"
 }
 


### PR DESCRIPTION
Using public and private subnets from the assigned VPC was causing network issues when attempting external connections.
We should also be using a custom security group for lambdas.

![image](https://github.com/user-attachments/assets/01acc886-4e4b-41e4-b9cf-10819f9224ef)

