### PR TITLE
Add healthcheck lambda

### DIFF
--- a/healthcheck/lambda_function.py
+++ b/healthcheck/lambda_function.py
@@ -1,0 +1,53 @@
+
+import access_token
+import database
+import environment
+import logging as pylogging
+import os
+import requests
+
+logging = pylogging.getLogger()
+logging.setLevel("INFO")
+
+
+def lambda_handler(_event, _context):
+    # Environment vars from lambda and secrets manager
+    logging.info("Seeding environment")
+    environment.seed()
+    for key in environment.KEYS:
+        if os.getenv(key):
+            logging.info("env var %s present", key)
+
+    logging.info("Environment populated with secrets from secretsmanager")
+
+    # Database check
+    logging.info("Checking database connectivity")
+
+    with database.cursor() as cursor:
+        logging.info("Database connection established")
+        logging.info("Executing database query")
+
+        cursor.execute(
+            """
+            SELECT COUNT(*) FROM v_notify_message_queue
+            """
+        )
+        result = cursor.fetchone()
+
+        logging.info("Database query results (number of queued recipients): %s", result[0])
+        logging.info("Database check complete")
+
+    # OAuth check
+    logging.info("OAuth2 check")
+    token = access_token.get_token()
+    logging.info("Access token: %s", token)
+
+    logging.info("Communication Management API (CMAPI) check")
+    response = requests.get(f"{os.getenv('COMMGT_BASE_URL')}/healthcheck", timeout=30)
+    logging.info("Response from CMAPI healthcheck: %s", response.status_code)
+    logging.info(response.text)
+    logging.info("CMAPI check complete")
+
+    logging.info("All checks complete")
+
+    return {"status": "success"}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -26,6 +26,7 @@ module "lambdas" {
 
   batch_notification_processor_lambda_role_arn = module.iam.batch_notification_processor_lambda_role_arn
   message_status_handler_lambda_role_arn       = module.iam.message_status_handler_lambda_role_arn
+  healthcheck_lambda_role_arn                  = module.iam.healthcheck_lambda_role_arn
   python_packages_layer_arn                    = module.lambda_layer.python_packages_layer_arn
 }
 

--- a/terraform/modules/iam/main.tf
+++ b/terraform/modules/iam/main.tf
@@ -49,6 +49,17 @@ data "aws_iam_policy_document" "lambda_kms_policy_document" {
   }
 }
 
+resource "aws_iam_policy" "message_status_handler_secretsmanager_policy" {
+  name   = "${var.team}-${var.project}-message-status-handler-secretsmanager-policy-${var.environment}"
+  policy = data.aws_iam_policy_document.lambda_secretsmanager_policy_document.json
+  tags   = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "message_status_handler_lambda_secretsmanager_access" {
+  role       = aws_iam_role.message_status_handler_lambda_role.name
+  policy_arn = aws_iam_policy.message_status_handler_secretsmanager_policy.arn
+}
+
 resource "aws_iam_policy" "message_status_handler_kms_policy" {
   name   = "${var.team}-${var.project}-message-status-handler-kms-policy-${var.environment}"
   policy = data.aws_iam_policy_document.lambda_kms_policy_document.json
@@ -201,4 +212,55 @@ resource "aws_iam_policy" "batch_notification_processor_sqs_policy" {
 resource "aws_iam_role_policy_attachment" "batch_notification_processor_lambda_sqs_access" {
   role       = aws_iam_role.batch_notification_processor_lambda_role.name
   policy_arn = aws_iam_policy.batch_notification_processor_sqs_policy.arn
+}
+
+resource "aws_iam_role" "healthcheck_lambda_role" {
+  name = "${var.team}-${var.project}-healthcheck-lambda-role-${var.environment}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = "sts:AssumeRole",
+        Effect = "Allow",
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "healthcheck_lambda_role_policy_attachment" {
+  role       = aws_iam_role.healthcheck_lambda_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy_attachment" "healthcheck_lambda_role_vpc_access_policy_attachment" {
+  role       = aws_iam_role.healthcheck_lambda_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+}
+
+resource "aws_iam_policy" "healthcheck_secretsmanager_policy" {
+  name   = "${var.team}-${var.project}-healthcheck-secretsmanager-policy-${var.environment}"
+  policy = data.aws_iam_policy_document.lambda_secretsmanager_policy_document.json
+  tags   = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "healthcheck_lambda_secretsmanager_access" {
+  role       = aws_iam_role.healthcheck_lambda_role.name
+  policy_arn = aws_iam_policy.healthcheck_secretsmanager_policy.arn
+}
+
+resource "aws_iam_policy" "healthcheck_kms_policy" {
+  name   = "${var.team}-${var.project}-healthcheck-kms-policy-${var.environment}"
+  policy = data.aws_iam_policy_document.lambda_kms_policy_document.json
+  tags   = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "healthcheck_lambda_kms_access" {
+  role       = aws_iam_role.healthcheck_lambda_role.name
+  policy_arn = aws_iam_policy.healthcheck_kms_policy.arn
 }

--- a/terraform/modules/iam/outputs.tf
+++ b/terraform/modules/iam/outputs.tf
@@ -6,3 +6,6 @@ output "message_status_handler_lambda_role_arn" {
   value = aws_iam_role.message_status_handler_lambda_role.arn
 }
 
+output "healthcheck_lambda_role_arn" {
+  value = aws_iam_role.healthcheck_lambda_role.arn
+}

--- a/terraform/modules/lambdas/variables.tf
+++ b/terraform/modules/lambdas/variables.tf
@@ -31,7 +31,12 @@ variable "batch_notification_processor_lambda_role_arn" {
 
 variable "message_status_handler_lambda_role_arn" {
   type        = string
-  description = "ARN for the batch processor lambda role"
+  description = "ARN for the message status handler lambda role"
+}
+
+variable "healthcheck_lambda_role_arn" {
+  type        = string
+  description = "ARN for the healthcheck lambda role"
 }
 
 variable "parameters_and_secrets_lambda_extension_arn" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -23,11 +23,6 @@ variable "kms_arn" {
   default = "arn:aws:kms:eu-west-2:123456789012:key/fe1a2b3c-4d5e-6f7g-8h9i-j0k1l2m3n4o5"
 }
 
-variable "scheduler_arn" {
-  type    = string
-  default = "arn:aws:scheduler:eu-west-2:123456789012:schedule/bcss-nonprod-scheduler"
-}
-
 variable "secrets_arn" {
   type    = string
   default = "arn:aws:secretsmanager:eu-west-2:123456789012:secret:bcss-nonprod-secrets-123456"
@@ -40,4 +35,3 @@ variable "tags" {
   }
   description = "A map of tags to apply to the resource."
 }
-

--- a/tests/unit/shared/test_access_token.py
+++ b/tests/unit/shared/test_access_token.py
@@ -6,7 +6,7 @@ import cryptography.hazmat.primitives.asymmetric.rsa as rsa
 from cryptography.hazmat.primitives import serialization
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def setup(monkeypatch):
     """Set up environment variables and private key for tests."""
     monkeypatch.setenv("OAUTH_TOKEN_URL", "http://tokens.example.com")
@@ -24,7 +24,7 @@ def setup(monkeypatch):
     monkeypatch.setenv("PRIVATE_KEY", private_key_pem)
 
 
-def test_get_token_successful_response(setup):
+def test_get_token_successful_response():
     """Test that a valid response returns the expected access token."""
     with requests_mock.Mocker() as mock:
         mock.post(
@@ -36,7 +36,7 @@ def test_get_token_successful_response(setup):
         assert token == "an_access_token"
 
 
-def test_get_token_error_response(setup, mocker):
+def test_get_token_error_response(mocker):
     """Test that an error response results in an empty token and logs errors."""
     error_logging_spy = mocker.spy(logging, "error")
 


### PR DESCRIPTION
Adds a lambda function which runs through a series of checks which help inform us of connectivity issues with any of the external dependencies / services we rely on for BCSS Notifications.

I was unsure of whether to add a unit test for this lambda as its job is to call code we've unit tested elsewhere. 
Also not sure whether we would want to schedule it to run daily before other lambdas run to give an early warning of connectivity issues.
Something to discuss.

![image](https://github.com/user-attachments/assets/ccbd70d2-c288-4320-b915-e11379666562)
