### PR TITLE
Set lambda log levels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,3 +53,5 @@ jsonschema = "^4.23.0"
 pylint = "^3.3.7"
 pact-python = "^2.3.1"
 
+[tool.poetry.requires-plugins]
+poetry-plugin-export = ">=1.9"

--- a/terraform/config/development.tfvars
+++ b/terraform/config/development.tfvars
@@ -3,9 +3,8 @@ team        = "bcss"
 project     = "comms"
 region      = "eu-west-2"
 
-kms_arn       = "arn:aws:kms:eu-west-2:730319765130:key/25da03db-7a99-4a15-bc38-2bf757f27fca"
-scheduler_arn = "arn:aws:scheduler:eu-west-2:730319765130:schedule/default/lambda_status_check"
-secrets_arn   = "arn:aws:secretsmanager:eu-west-2:730319765130:secret:bcss-nonprod-notify-lambda-secrets-A8O202"
+kms_arn     = "arn:aws:kms:eu-west-2:730319765130:key/25da03db-7a99-4a15-bc38-2bf757f27fca"
+secrets_arn = "arn:aws:secretsmanager:eu-west-2:730319765130:secret:bcss-nonprod-notify-lambda-secrets-A8O202"
 
 tags = {
   "Service" = "bcss"

--- a/terraform/config/production.tfvars
+++ b/terraform/config/production.tfvars
@@ -5,7 +5,6 @@ region      = "eu-west-2"
 
 # TODO: ARNs TBC
 kms_arn       = "arn:aws:kms:eu-west-2:730319765130:key/25da03db-7a99-4a15-bc38-2bf757f27fca"
-scheduler_arn = "arn:aws:scheduler:eu-west-2:730319765130:schedule/default/lambda_status_check"
 secrets_arn   = "arn:aws:secretsmanager:eu-west-2:730319765130:secret:TBC"
 region        = "eu-west-2"
 

--- a/terraform/modules/lambdas/main.tf
+++ b/terraform/modules/lambdas/main.tf
@@ -26,6 +26,11 @@ resource "aws_lambda_function" "batch_notification_processor" {
   source_code_hash = local.build_trigger
   timeout          = 300
 
+  logging_config {
+    application_log_level = "INFO"
+    log_format            = "JSON"
+  }
+
   vpc_config {
     subnet_ids         = var.subnet_ids
     security_group_ids = [var.security_group]
@@ -76,6 +81,11 @@ resource "aws_lambda_function" "message_status_handler" {
   runtime          = local.runtime
   source_code_hash = local.build_trigger
   timeout          = 300
+
+  logging_config {
+    application_log_level = "INFO"
+    log_format            = "JSON"
+  }
 
   vpc_config {
     subnet_ids         = var.subnet_ids
@@ -137,6 +147,11 @@ resource "aws_lambda_function" "healthcheck" {
   runtime          = local.runtime
   source_code_hash = local.build_trigger
   timeout          = 300
+
+  logging_config {
+    application_log_level = "INFO"
+    log_format            = "JSON"
+  }
 
   vpc_config {
     subnet_ids         = var.subnet_ids


### PR DESCRIPTION
This PR does 3 things:

- Adds missing `poerty export` plugin to `pyproject.toml`. Without it `terraform apply` fails
- Configures Lambda application logging at INFO level
- Removes some unused references to scheduler ARNs