### PR TITLE
Improve lambda log output

### DIFF
--- a/batch_notification_processor/lambda_function.py
+++ b/batch_notification_processor/lambda_function.py
@@ -2,42 +2,37 @@
 
 import batch_processor
 import environment
-import logging as pylogging
-import os
+import logging
 import communication_management
-
-logging = pylogging.getLogger()
-logging.setLevel(os.getenv("LOG_LEVEL", "INFO"))
-
 
 def lambda_handler(_event: dict, _context: object) -> dict:
     """
     AWS Lambda handler to process and send batch notifications.
     """
-    logging.info("Lambda function has started.")
+    logging.info("Batch notification processor lambda function has started.")
 
     environment.seed()
 
     batch_id, routing_plan_id, recipients = batch_processor.next_batch()
-    batches = [batch_id]
+    batches = []
+
+    logging.info("Processing next batch. (batch_id: %s, routing_plan_id: %s, recipients: %s)", batch_id, routing_plan_id, recipients)
 
     while routing_plan_id and recipients:
-        logging.info("Batch ID: %s, Routing plan ID: %s, Recipients: %s", batch_id, routing_plan_id, recipients)
-
         response = communication_management.send_batch_message(
             batch_id, routing_plan_id, recipients
         )
 
         if response.status_code == 201:
             batch_processor.mark_batch_as_sent(batch_id)
-            batches.append(batch_id)
+            batches.append({"batch_id": batch_id, "routing_plan_id": routing_plan_id, "recipients": recipients})
             logging.info("Batch %s sent successfully to %s recipients.", batch_id, len(recipients))
         else:
             logging.error("Batch %s failed to send. Status code: %s. Response: %s", batch_id, response.status_code, response.text)
 
         batch_id, routing_plan_id, recipients = batch_processor.next_batch()
 
-    logging.info("Lambda function has completed processing. Batches sent: %s", batches)
+    logging.info("Batch notification processor lambda function has completed processing. Batches sent: %s", batches)
 
     return {
         "status": "complete",

--- a/healthcheck/lambda_function.py
+++ b/healthcheck/lambda_function.py
@@ -2,17 +2,14 @@
 import access_token
 import database
 import environment
-import logging as pylogging
+import logging
 import os
 import requests
-
-logging = pylogging.getLogger()
-logging.setLevel("INFO")
 
 
 def lambda_handler(_event, _context):
     # Environment vars from lambda and secrets manager
-    logging.info("Seeding environment")
+    logging.info("Healthcheck lambda check #1: Seeding environment from secrets manager")
     environment.seed()
     for key in environment.KEYS:
         if os.getenv(key):
@@ -21,7 +18,7 @@ def lambda_handler(_event, _context):
     logging.info("Environment populated with secrets from secretsmanager")
 
     # Database check
-    logging.info("Checking database connectivity")
+    logging.info("Healthcheck lambda #2: Checking database connectivity")
 
     with database.cursor() as cursor:
         logging.info("Database connection established")
@@ -38,16 +35,16 @@ def lambda_handler(_event, _context):
         logging.info("Database check complete")
 
     # OAuth check
-    logging.info("OAuth2 check")
+    logging.info("Healthcheck lambda check #3: OAuth2 check")
     token = access_token.get_token()
     logging.info("Access token: %s", token)
 
-    logging.info("Communication Management API (CMAPI) check")
+    logging.info("Healthcheck lambda check #4: Make request to Communication Management API (CMAPI)")
     response = requests.get(f"{os.getenv('COMMGT_BASE_URL')}/healthcheck", timeout=30)
     logging.info("Response from CMAPI healthcheck: %s", response.status_code)
     logging.info(response.text)
     logging.info("CMAPI check complete")
 
-    logging.info("All checks complete")
+    logging.info("Healthcheck lambda: All checks complete")
 
     return {"status": "success"}

--- a/message_status_handler/scheduled_lambda_function.py
+++ b/message_status_handler/scheduled_lambda_function.py
@@ -1,18 +1,14 @@
 import communication_management
 import environment
 import json
-import logging as pylogging
-import os
+import logging
 import batch_fetcher
 import message_status_recorder
 from typing import Dict, Any
 
-logging = pylogging.getLogger()
-logging.setLevel(os.getenv("LOG_LEVEL", "INFO"))
-
 
 def lambda_handler(_event: Any, _context: Any) -> Dict[str, Any]:
-    logging.info("Message status handler started.")
+    logging.info("Message status handler lambda has started.")
     environment.seed()
     results = {}
     try:
@@ -31,11 +27,14 @@ def lambda_handler(_event: Any, _context: Any) -> Dict[str, Any]:
                 bcss_responses = message_status_recorder.record_message_statuses(batch_id, messages_with_read_status)
                 results[batch_id]["bcss_response"] = bcss_responses
 
+        logging.info("Message status handler lambda has finished.")
+        logging.info("Results: %s", results)
+
         return {
             "statusCode": 200,
             "body": json.dumps(
                 {
-                    "message": "Message status handler finished",
+                    "message": "Message status handler lambda finished",
                     "data": results,
                 }
             ),

--- a/tests/unit/message_status_handler/test_scheduled_lambda_function.py
+++ b/tests/unit/message_status_handler/test_scheduled_lambda_function.py
@@ -15,7 +15,7 @@ def test_lambda_handler(mock_record_message_statuses, mock_get_read_messages, mo
 
     assert response["statusCode"] == 200
     assert json.loads(response["body"]) == {
-        "message": "Message status handler finished",
+        "message": "Message status handler lambda finished",
         "data": {
             "12345": {
                 "notification_status": [{"message_id": "123", "status": "read"}],
@@ -35,7 +35,7 @@ def test_lambda_handler_no_messages(mock_get_read_messages, mock_fetch_batch_ids
 
     assert response["statusCode"] == 200
     assert json.loads(response["body"]) == {
-        "message": "Message status handler finished",
+        "message": "Message status handler lambda finished",
         "data": {
             "12345": {
                 "notification_status": [],


### PR DESCRIPTION
We no longer need logging level configuration in the lambda code as we set this in Terraform now.
This PR removes unnecessary config and makes logging statements clearer for lambda execution.