### PR TITLE
Reduce oracle view fetch results

### DIFF
--- a/batch_notification_processor/oracle_database.py
+++ b/batch_notification_processor/oracle_database.py
@@ -22,7 +22,15 @@ def get_recipients(batch_id: str) -> list[Recipient]:
     with database.cursor() as cursor:
         try:
             cursor.execute(
-                "SELECT * FROM v_notify_message_queue WHERE batch_id = :batch_id",
+                """
+                SELECT nhs_number,
+                       message_id,
+                       batch_id,
+                       routing_plan_id,
+                       message_status
+                FROM v_notify_message_queue
+                WHERE batch_id = :batch_id
+                """,
                 {"batch_id": batch_id},
             )
             recipient_data = cursor.fetchall()

--- a/shared/recipient.py
+++ b/shared/recipient.py
@@ -9,11 +9,3 @@ class Recipient(NamedTuple):
     batch_id: str | None = None
     routing_plan_id: str | None = None
     message_status: str | None = None
-    variable_text_1: str | None = None
-    address_line_1: str | None = None
-    address_line_2: str | None = None
-    address_line_3: str | None = None
-    address_line_4: str | None = None
-    address_line_5: str | None = None
-    postcode: str | None = None
-    gp_practice_name: str | None = None

--- a/tests/unit/batch_notification_processor/test_oracle_database.py
+++ b/tests/unit/batch_notification_processor/test_oracle_database.py
@@ -49,7 +49,17 @@ def test_get_recipients(mock_database):
     recipients = oracle_database.get_recipients(batch_id)
 
     mock_cursor.execute.assert_called_with(
-        "SELECT * FROM v_notify_message_queue WHERE batch_id = :batch_id", {'batch_id': batch_id})
+                """
+                SELECT nhs_number,
+                       message_id,
+                       batch_id,
+                       routing_plan_id,
+                       message_status
+                FROM v_notify_message_queue
+                WHERE batch_id = :batch_id
+                """,
+        {'batch_id': batch_id}
+    )
 
     assert len(recipients) == 2
     assert isinstance(recipients[0], Recipient)

--- a/tests/unit/shared/test_recipient.py
+++ b/tests/unit/shared/test_recipient.py
@@ -3,10 +3,7 @@ from recipient import Recipient
 
 class TestRecipient:
     def test_recipient(self):
-        recipient_data = ("1234567890", "message_reference_0", "abc123", "routing_plan_id",
-                          "message_status", "variable_text_1", "address_line_1",
-                          "address_line_2", "address_line_3", "address_line_4",
-                          "address_line_5", "postcode", "gp_practice_name")
+        recipient_data = ("1234567890", "message_reference_0", "abc123", "routing_plan_id", "message_status")
         recipient = Recipient(*recipient_data)
 
         assert recipient.nhs_number == "1234567890"
@@ -14,14 +11,6 @@ class TestRecipient:
         assert recipient.batch_id == "abc123"
         assert recipient.routing_plan_id == "routing_plan_id"
         assert recipient.message_status == "message_status"
-        assert recipient.variable_text_1 == "variable_text_1"
-        assert recipient.address_line_1 == "address_line_1"
-        assert recipient.address_line_2 == "address_line_2"
-        assert recipient.address_line_3 == "address_line_3"
-        assert recipient.address_line_4 == "address_line_4"
-        assert recipient.address_line_5 == "address_line_5"
-        assert recipient.postcode == "postcode"
-        assert recipient.gp_practice_name == "gp_practice_name"
 
     def test_recipient_with_partial_data(self):
         recipient_data = ("1234567890", "message_reference_0")
@@ -32,14 +21,6 @@ class TestRecipient:
         assert recipient.batch_id is None
         assert recipient.routing_plan_id is None
         assert recipient.message_status is None
-        assert recipient.variable_text_1 is None
-        assert recipient.address_line_1 is None
-        assert recipient.address_line_2 is None
-        assert recipient.address_line_3 is None
-        assert recipient.address_line_4 is None
-        assert recipient.address_line_5 is None
-        assert recipient.postcode is None
-        assert recipient.gp_practice_name is None
 
     def test_recipient_attribute_assignment(self):
         recipient_data = ("1234567890", "message_reference_0", "abc123", "routing_plan_id")


### PR DESCRIPTION
We only use the fields `nhs_number`, `message_id`, `batch_id`, `routing_plan_id` and `message_status` from the `v_notify_message_queue` view so restrict the fetching of recipient data to this as we do not need address data.