### PR TITLE
Add poetry export plugin as documented

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,8 @@ dependencies = [
     "virtualenv (>=20.31.2,<21.0.0)"
 ]
 
+[project.entry-points."poetry.application.plugin"]
+export = "poetry_plugin_export.plugins:ExportApplicationPlugin"
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]
@@ -52,6 +54,3 @@ pytest-mock = "^3.14.1"
 jsonschema = "^4.24.0"
 pylint = "^3.3.7"
 pact-python = "^2.3.1"
-
-[tool.poetry.requires-plugins]
-poetry-plugin-export = ">=1.9"


### PR DESCRIPTION
I attempted to add poetry export plugin here https://github.com/NHSDigital/bcss-notifications/pull/109/commits/f82e2fd9ac9c1b1a14da97c07768f7de95cb0c41 but this evidently did not work for GH CI runners. This PR adds as described in `pyproject.toml` docs: https://python-poetry.org/docs/pyproject/#entry-points