### PR TITLE
Add address personalisation data necessary for BCSS Notify templates

### DIFF
--- a/batch_notification_processor/oracle_database.py
+++ b/batch_notification_processor/oracle_database.py
@@ -27,7 +27,13 @@ def get_recipients(batch_id: str) -> list[Recipient]:
                        message_id,
                        batch_id,
                        routing_plan_id,
-                       message_status
+                       message_status,
+                       address_line_1,
+                       address_line_2,
+                       address_line_3,
+                       address_line_4,
+                       address_line_5,
+                       postcode
                 FROM v_notify_message_queue
                 WHERE batch_id = :batch_id
                 """,

--- a/shared/communication_management.py
+++ b/shared/communication_management.py
@@ -79,12 +79,21 @@ def generate_batch_message_request_body(
     }
 
 
+# pylint: disable=no-member
 def generate_message(recipient) -> dict:
     return {
-        "messageReference": recipient.message_id, # pylint: disable=no-member
-        "recipient": {"nhsNumber": recipient.nhs_number}, # pylint: disable=no-member
-        "personalisation": {},
+        "messageReference": recipient.message_id,
+        "recipient": {"nhsNumber": recipient.nhs_number},
+        "personalisation": {
+            "address_line_1_bcss": recipient.address_line_1,
+            "address_line_2_bcss": recipient.address_line_2,
+            "address_line_3_bcss": recipient.address_line_3,
+            "address_line_4_bcss": recipient.address_line_4,
+            "address_line_5_bcss": recipient.address_line_5,
+            "address_line_6_bcss": recipient.postcode,
+        },
     }
+# pylint: enable=no-member
 
 
 def generate_hmac_signature(request_body: dict) -> str:

--- a/shared/recipient.py
+++ b/shared/recipient.py
@@ -9,3 +9,9 @@ class Recipient(NamedTuple):
     batch_id: str | None = None
     routing_plan_id: str | None = None
     message_status: str | None = None
+    address_line_1: str | None = None
+    address_line_2: str | None = None
+    address_line_3: str | None = None
+    address_line_4: str | None = None
+    address_line_5: str | None = None
+    postcode: str | None = None

--- a/tests/unit/batch_notification_processor/test_oracle_database.py
+++ b/tests/unit/batch_notification_processor/test_oracle_database.py
@@ -54,11 +54,17 @@ def test_get_recipients(mock_database):
                        message_id,
                        batch_id,
                        routing_plan_id,
-                       message_status
+                       message_status,
+                       address_line_1,
+                       address_line_2,
+                       address_line_3,
+                       address_line_4,
+                       address_line_5,
+                       postcode
                 FROM v_notify_message_queue
                 WHERE batch_id = :batch_id
                 """,
-        {'batch_id': batch_id}
+                {'batch_id': batch_id}
     )
 
     assert len(recipients) == 2

--- a/tests/unit/shared/test_communication_management.py
+++ b/tests/unit/shared/test_communication_management.py
@@ -25,8 +25,16 @@ def test_send_batch_message(mock_get_token):
             "batch_id",
             "routing_config_id",
             [
-                Recipient("0000000000", "message_reference_0", "requested"),
-                Recipient("1111111111", "message_reference_1", "requested"),
+                Recipient(
+                    "0000000000", "message_reference_0", "batch_id_0", "requested",
+                    "routing_config_id_0", "address_line_01", "address_line_02",
+                    "address_line_03", "address_line_04", "address_line_05", "postcode_0"
+                ),
+                Recipient(
+                    "1111111111", "message_reference_1", "batch_id_1", "requested",
+                    "routing_config_id_1", "address_line_11", "address_line_12",
+                    "address_line_13", "address_line_14", "address_line_15", "postcode_1"
+                ),
             ]
         )
         assert adapter.last_request.url == "http://example.com/message/batch"
@@ -42,12 +50,26 @@ def test_send_batch_message(mock_get_token):
                         {
                             "recipient": {"nhsNumber": "0000000000"},
                             "messageReference": "message_reference_0",
-                            "personalisation": {},
+                            "personalisation": {
+                                "address_line_1_bcss": "address_line_01",
+                                "address_line_2_bcss": "address_line_02",
+                                "address_line_3_bcss": "address_line_03",
+                                "address_line_4_bcss": "address_line_04",
+                                "address_line_5_bcss": "address_line_05",
+                                "address_line_6_bcss": "postcode_0",
+                            },
                         },
                         {
                             "recipient": {"nhsNumber": "1111111111"},
                             "messageReference": "message_reference_1",
-                            "personalisation": {},
+                            "personalisation": {
+                                "address_line_1_bcss": "address_line_11",
+                                "address_line_2_bcss": "address_line_12",
+                                "address_line_3_bcss": "address_line_13",
+                                "address_line_4_bcss": "address_line_14",
+                                "address_line_5_bcss": "address_line_15",
+                                "address_line_6_bcss": "postcode_1",
+                            },
                         },
                     ],
                 },
@@ -73,13 +95,24 @@ def test_generate_batch_message_request_body():
 
 
 def test_generate_message():
-    recipient = Recipient("0000000000", "message_reference_0", "requested")
+    recipient = Recipient(
+        "0000000000", "message_reference_0", "batch_id_0", "requested",
+        "routing_config_id_0", "address_line_01", "address_line_02",
+        "address_line_03", "address_line_04", "address_line_05", "postcode_0"
+    )
 
     message = communication_management.generate_message(recipient)
 
     assert message["messageReference"] == "message_reference_0"
     assert message["recipient"]["nhsNumber"] == "0000000000"
-    assert message["personalisation"] == {}
+    assert message["personalisation"] == {
+        "address_line_1_bcss": "address_line_01",
+        "address_line_2_bcss": "address_line_02",
+        "address_line_3_bcss": "address_line_03",
+        "address_line_4_bcss": "address_line_04",
+        "address_line_5_bcss": "address_line_05",
+        "address_line_6_bcss": "postcode_0",
+    }
 
 
 def test_generate_hmac_signature():

--- a/tests/unit/shared/test_recipient.py
+++ b/tests/unit/shared/test_recipient.py
@@ -1,35 +1,46 @@
 from recipient import Recipient
 
 
-class TestRecipient:
-    def test_recipient(self):
-        recipient_data = ("1234567890", "message_reference_0", "abc123", "routing_plan_id", "message_status")
-        recipient = Recipient(*recipient_data)
+def test_recipient():
+    recipient_data = (
+        "1234567890", "message_reference_0", "abc123", "routing_plan_id",
+        "message_status", "address_line_1", "address_line_2",
+        "address_line_3", "address_line_4", "address_line_5", "postcode"
+    )
+    recipient = Recipient(*recipient_data)
 
-        assert recipient.nhs_number == "1234567890"
-        assert recipient.message_id == "message_reference_0"
-        assert recipient.batch_id == "abc123"
-        assert recipient.routing_plan_id == "routing_plan_id"
-        assert recipient.message_status == "message_status"
+    assert recipient.nhs_number == "1234567890"
+    assert recipient.message_id == "message_reference_0"
+    assert recipient.batch_id == "abc123"
+    assert recipient.routing_plan_id == "routing_plan_id"
+    assert recipient.message_status == "message_status"
+    assert recipient.address_line_1 == "address_line_1"
+    assert recipient.address_line_2 == "address_line_2"
+    assert recipient.address_line_3 == "address_line_3"
+    assert recipient.address_line_4 == "address_line_4"
+    assert recipient.address_line_5 == "address_line_5"
+    assert recipient.postcode == "postcode"
 
-    def test_recipient_with_partial_data(self):
-        recipient_data = ("1234567890", "message_reference_0")
-        recipient = Recipient(*recipient_data)
 
-        assert recipient.nhs_number == "1234567890"
-        assert recipient.message_id == "message_reference_0"
-        assert recipient.batch_id is None
-        assert recipient.routing_plan_id is None
-        assert recipient.message_status is None
+def test_recipient_with_partial_data():
+    recipient_data = ("1234567890", "message_reference_0")
+    recipient = Recipient(*recipient_data)
 
-    def test_recipient_attribute_assignment(self):
-        recipient_data = ("1234567890", "message_reference_0", "abc123", "routing_plan_id")
-        recipient = Recipient(*recipient_data)
+    assert recipient.nhs_number == "1234567890"
+    assert recipient.message_id == "message_reference_0"
+    assert recipient.batch_id is None
+    assert recipient.routing_plan_id is None
+    assert recipient.message_status is None
 
-        recipient = recipient._replace(
-            message_id="message_reference",
-            message_status="message_status"
-        )
 
-        assert recipient.message_id == "message_reference"
-        assert recipient.message_status == "message_status"
+def test_recipient_attribute_assignment():
+    recipient_data = ("1234567890", "message_reference_0", "abc123", "routing_plan_id")
+    recipient = Recipient(*recipient_data)
+
+    recipient = recipient._replace(
+        message_id="message_reference",
+        message_status="message_status"
+    )
+
+    assert recipient.message_id == "message_reference"
+    assert recipient.message_status == "message_status"


### PR DESCRIPTION
## Context

The _Check your address_ section of the BCSS notification templates displays the recipient's address.
For this to be present in the rendered template we need to fetch the address fields from `v_notify_message_queue` and include them in the personalisation JSON sent to NHS Notify.

## Changes

- (Re)Add recipient address fields to Recipient data structure
- Fetch address fields from Oracle view
- Include address fields in personalisation JSON in Notify POST body