### PR TITLE
[Bugfix] Build a new array of recipients when we populate message references

### DIFF
--- a/batch_notification_processor/batch_processor.py
+++ b/batch_notification_processor/batch_processor.py
@@ -37,18 +37,19 @@ def get_routing_plan_id(batch_id):
 
 def get_recipients(batch_id):
     recipients = []
+    recipients_results = []
 
     try:
-        recipients = oracle_database.get_recipients(batch_id)
-        if not recipients:
+        recipients_results = oracle_database.get_recipients(batch_id)
+        if not recipients_results:
             logging.error("No recipients for batch ID: %s", batch_id)
     except oracledb.Error as e:
         logging.error("Error fetching recipients: %s", e)
 
-    for idx, recipient in enumerate(recipients):
+    for recipient in recipients_results:
         recipient = recipient._replace(message_id=generate_message_reference())
         oracle_database.update_message_id(recipient)
-        recipients[idx] = recipient
+        recipients.append(recipient)
 
     return recipients
 


### PR DESCRIPTION
We were encountering a runtime error in attempting to overwrite the enumerated recipients. 
It's cleaner to just append to a fresh array once the message references have been assigned.

This PR also makes some of the mocking around generating references clearer and (re)asserts that message references have been updated correctly.