### PR TITLE
Fix callback payload expectations

### DIFF
--- a/message_status_handler/callback_lambda_function.py
+++ b/message_status_handler/callback_lambda_function.py
@@ -17,14 +17,15 @@ def lambda_handler(event: Any, _context: Any) -> Dict[str, Any]:
         json_body = json.loads(body)
 
         if request_verifier.verify_request(headers, json_body):
-            bcss_response = message_status_recorder.record_message_status(json_body)
-            result = {"bcss_response_code": bcss_response}
+            bcss_response_codes = message_status_recorder.record_message_statuses(json_body)
+            result = {"bcss_response_codes": bcss_response_codes}
 
         return {
             "status": 200,
             "body": json.dumps(
                 {
                     "message": "Message status handler lambda finished",
+                    "event": event,
                     "result": result
                 }
             ),

--- a/message_status_handler/message_status_recorder.py
+++ b/message_status_handler/message_status_recorder.py
@@ -1,9 +1,18 @@
 import database
 
 
+def record_message_statuses(json_data: dict):
+    response_codes = []
+    for data in json_data.get('data', [{}]):
+        response_code = record_message_status(data)
+        response_codes.append(response_code)
+
+    return response_codes
+
+
 def record_message_status(json_data: dict):
     response_code = 0
-    message_reference = json_data.get('data', {}).get('attributes', {}).get('messageReference')
+    message_reference = json_data.get('attributes', {}).get('messageReference')
 
     if message_reference is not None:
         with database.cursor() as cursor:

--- a/message_status_handler/request_verifier.py
+++ b/message_status_handler/request_verifier.py
@@ -51,7 +51,11 @@ def verify_signature(headers: dict, body: dict) -> bool:
 
 
 def verify_body(body: dict) -> bool:
-    data = body.get('data', {})
+    data = body.get('data', [{}])
+    return all(verify_data(d) for d in data)
+
+
+def verify_data(data: dict) -> bool:
     if data.get('type') == 'ChannelStatus':
         attributes = data.get('attributes', {})
         return (

--- a/tests/integration/test_message_status_handler_updates_statuses.py
+++ b/tests/integration/test_message_status_handler_updates_statuses.py
@@ -17,14 +17,16 @@ def test_message_status_handler_updates_message_status(recipient_data, helpers):
     helpers.call_get_next_batch(batch_id)
     helpers.mark_batch_as_sent(batch_id)
     request_body = {
-        "data": {
-            "type": "ChannelStatus",
-            "attributes": {
-                "channel": "nhsapp",
-                "supplierStatus": "read",
-                "messageReference": message_references[0]
+        "data": [
+            {
+                "type": "ChannelStatus",
+                "attributes": {
+                    "channel": "nhsapp",
+                    "supplierStatus": "read",
+                    "messageReference": message_references[0]
+                }
             }
-        }
+        ]
     }
     headers = {
         "Content-Type": "application/json",
@@ -52,14 +54,16 @@ def test_message_status_handler_updates_message_status(recipient_data, helpers):
 def test_message_status_handler_invalid_request(helpers):
     """Test that the message status handler does nothing for invalid requests."""
     request_body = {
-        "data": {
-            "type": "ChannelStatus",
-            "attributes": {
-                "channel": "nhsapp",
-                "supplierStatus": "read",
-                "messageId": "invalid-message-id"
+        "data": [
+            {
+                "type": "ChannelStatus",
+                "attributes": {
+                    "channel": "nhsapp",
+                    "supplierStatus": "read",
+                    "messageId": "invalid-message-id"
+                }
             }
-        }
+        ]
     }
     headers = {
         "Content-Type": "application/json",

--- a/tests/unit/message_status_handler/test_request_verifier.py
+++ b/tests/unit/message_status_handler/test_request_verifier.py
@@ -14,14 +14,14 @@ def setup(monkeypatch):
 def test_verify_signature_invalid():
     """Test that an invalid signature fails verification."""
     headers = {request_verifier.SIGNATURE_HEADER_NAME: 'signature'}
-    body = {'data': 'body'}
+    body = {'data': [{'body': 'valid'}]}
 
     assert not request_verifier.verify_signature(headers, body)
 
 
 def test_verify_signature_valid():
     """Test that a valid signature passes verification."""
-    body = {'data': 'body'}
+    body = {'data': [{'body': 'valid'}]}
     signature = request_verifier.create_digest('application_id.api_key', json.dumps(body))
 
     headers = {request_verifier.SIGNATURE_HEADER_NAME: signature}
@@ -63,26 +63,26 @@ def test_verify_headers_invalid_api_key():
 
 def test_verify_body_invalid_type():
     """Test that an invalid body type fails verification."""
-    body = {'data': {'type': 'InvalidType', 'attributes': {}}}
+    body = {'data': [{'type': 'InvalidType', 'attributes': {}}]}
     assert not request_verifier.verify_body(body)
 
 
 def test_verify_body_invalid_attributes():
     """Test that an invalid body attributes fails verification."""
-    body = {'data': {'type': 'ChannelStatus', 'attributes': {'channel': 'nhsapp', 'supplierStatus': 'unread'}}}
+    body = {'data': [{'type': 'ChannelStatus', 'attributes': {'channel': 'nhsapp', 'supplierStatus': 'unread'}}]}
     assert not request_verifier.verify_body(body)
 
 
 def test_verify_body_valid():
     """Test that a valid body passes verification."""
-    body = {'data': {'type': 'ChannelStatus', 'attributes': {'channel': 'nhsapp', 'supplierStatus': 'read'}}}
+    body = {'data': [{'type': 'ChannelStatus', 'attributes': {'channel': 'nhsapp', 'supplierStatus': 'read'}}]}
     assert request_verifier.verify_body(body)
 
 
 def test_verify_request_invalid_headers():
     """Test that invalid headers fail request verification."""
     headers = {request_verifier.API_KEY_HEADER_NAME: 'invalid_api_key'}
-    body = {'data': {'type': 'ChannelStatus', 'attributes': {'channel': 'nhsapp', 'supplierStatus': 'read'}}}
+    body = {'data': [{'type': 'ChannelStatus', 'attributes': {'channel': 'nhsapp', 'supplierStatus': 'read'}}]}
 
     assert not request_verifier.verify_request(headers, body)
 
@@ -98,6 +98,6 @@ def test_verify_request_for_valid_request():
         request_verifier.SIGNATURE_HEADER_NAME: 'signature',
     }
 
-    body = {'data': {'type': 'ChannelStatus', 'attributes': {'channel': 'nhsapp', 'supplierStatus': 'read'}}}
+    body = {'data': [{'type': 'ChannelStatus', 'attributes': {'channel': 'nhsapp', 'supplierStatus': 'read'}}]}
 
     assert request_verifier.verify_request(headers, body) is True


### PR DESCRIPTION
## Context

![image](https://github.com/user-attachments/assets/8de8404d-1acf-466c-b6f1-068566415fb2)

Callback payloads from NHS Notify are JSON with a top level `data` property which has an array value. We currently expect an object value which is wrong.

## Changes

Fix expectations and handling of `data` property as an array. We suspect this will always contain one item only for BCSS but adds the ability to record statuses of multiple items in the `data` array.

Mobbed/paired with @dnimmo and @cameronhargreaves1-nhs on this.