### PR TITLE
Present empty string for null address fields

### DIFF
--- a/batch_notification_processor/notify_api.py
+++ b/batch_notification_processor/notify_api.py
@@ -32,6 +32,7 @@ def send_batch_message(
 
     return response
 
+
 def generate_batch_message_request_body(
     routing_config_id: str, message_batch_reference: str, recipients: list[Recipient]
 ) -> dict:
@@ -53,12 +54,12 @@ def generate_message(recipient) -> dict:
         "messageReference": recipient.message_id,
         "recipient": {"nhsNumber": recipient.nhs_number},
         "personalisation": {
-            "address_line_1_bcss": recipient.address_line_1,
-            "address_line_2_bcss": recipient.address_line_2,
-            "address_line_3_bcss": recipient.address_line_3,
-            "address_line_4_bcss": recipient.address_line_4,
-            "address_line_5_bcss": recipient.address_line_5,
-            "address_line_6_bcss": recipient.postcode,
+            "address_line_1_bcss": (recipient.address_line_1 or ""),
+            "address_line_2_bcss": (recipient.address_line_2 or ""),
+            "address_line_3_bcss": (recipient.address_line_3 or ""),
+            "address_line_4_bcss": (recipient.address_line_4 or ""),
+            "address_line_5_bcss": (recipient.address_line_5 or ""),
+            "address_line_6_bcss": (recipient.postcode or ""),
         },
     }
 # pylint: enable=no-member

--- a/pylintrc.toml
+++ b/pylintrc.toml
@@ -402,6 +402,7 @@ disable = [
     "too-many-return-statements",
     "wrong-import-order",
     "too-few-public-methods",
+    "unsupported-binary-operation",
 ]
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/shared/access_token.py
+++ b/shared/access_token.py
@@ -8,8 +8,6 @@ import uuid
 
 EXPIRES_IN_MINUTES = 5
 
-# pylint: disable=unsupported-binary-operation
-
 
 def get_token() -> str:
     if not os.getenv("OAUTH_API_KEY"):

--- a/shared/recipient.py
+++ b/shared/recipient.py
@@ -1,7 +1,5 @@
 from typing import NamedTuple
 
-# pylint: disable=unsupported-binary-operation
-
 
 class Recipient(NamedTuple):
     nhs_number: str | None = None

--- a/tests/unit/batch_notification_processor/test_notify_api.py
+++ b/tests/unit/batch_notification_processor/test_notify_api.py
@@ -112,3 +112,23 @@ def test_generate_message():
         "address_line_5_bcss": "address_line_05",
         "address_line_6_bcss": "postcode_0",
     }
+
+
+def test_generate_message_with_partial_data():
+    recipient = Recipient(
+        "0000000000", "message_reference_0", "batch_id_0", "requested",
+        "routing_config_id_0"
+    )
+
+    message = notify_api.generate_message(recipient)
+
+    assert message["messageReference"] == "message_reference_0"
+    assert message["recipient"]["nhsNumber"] == "0000000000"
+    assert message["personalisation"] == {
+        "address_line_1_bcss": "",
+        "address_line_2_bcss": "",
+        "address_line_3_bcss": "",
+        "address_line_4_bcss": "",
+        "address_line_5_bcss": "",
+        "address_line_6_bcss": "",
+    }

--- a/tests/unit/shared/test_recipient.py
+++ b/tests/unit/shared/test_recipient.py
@@ -44,3 +44,19 @@ def test_recipient_attribute_assignment():
 
     assert recipient.message_id == "message_reference"
     assert recipient.message_status == "message_status"
+
+
+def test_recipient_default_values():
+    recipient = Recipient()
+
+    assert recipient.nhs_number is None
+    assert recipient.message_id is None
+    assert recipient.batch_id is None
+    assert recipient.routing_plan_id is None
+    assert recipient.message_status is None
+    assert recipient.address_line_1 is None
+    assert recipient.address_line_2 is None
+    assert recipient.address_line_3 is None
+    assert recipient.address_line_4 is None
+    assert recipient.address_line_5 is None
+    assert recipient.postcode is None


### PR DESCRIPTION
## Context

NHS Notify will raise an error if any personalisation fields are `null` (why?!?!)

## Changes

1. Present an empty string for personalisation fields with a None value in the payload we send to Notify
2. Silence pesky `unsupported-binary-operation` pylint warnings, we want our type hints to use the convenient format like 
```python
def foo(): -> str | None
```