### PR TITLE
Allow VPC ID to be passed from environment tfvars config

### DIFF
--- a/terraform/config/development.tfvars
+++ b/terraform/config/development.tfvars
@@ -6,6 +6,8 @@ region      = "eu-west-2"
 kms_arn     = "arn:aws:kms:eu-west-2:730319765130:key/25da03db-7a99-4a15-bc38-2bf757f27fca"
 secrets_arn = "arn:aws:secretsmanager:eu-west-2:730319765130:secret:bcss-nonprod-notify-lambda-secrets-A8O202"
 
+selected_vpc_id = "vpc-09c7c54244a87b9d9"
+
 tags = {
   "Service" = "bcss"
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -70,6 +70,7 @@ module "iam" {
 }
 
 module "network" {
-  source = "./modules/network"
+  source          = "./modules/network"
+  selected_vpc_id = var.selected_vpc_id
 }
 

--- a/terraform/modules/network/variables.tf
+++ b/terraform/modules/network/variables.tf
@@ -1,0 +1,3 @@
+variable "selected_vpc_id" {
+  type    = string
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -28,6 +28,10 @@ variable "secrets_arn" {
   default = "arn:aws:secretsmanager:eu-west-2:123456789012:secret:bcss-nonprod-secrets-123456"
 }
 
+variable "selected_vpc_id" {
+  type = string
+}
+
 variable "tags" {
   type = map(string)
   default = {


### PR DESCRIPTION
We will need to configure a new VPC for new environments, this PR allows the VPC ID to be set from the environment config tfvars file.