### PR TITLE
Handle non-2xx responses from secrets endpoint

### DIFF
--- a/shared/environment.py
+++ b/shared/environment.py
@@ -19,6 +19,7 @@ KEYS = [
   "PRIVATE_KEY"
 ]
 
+
 class FetchSecretsError(BaseException):
     """Custom exception for fetch secrets errors."""
 
@@ -33,8 +34,12 @@ def seed() -> None:
         while not secrets and attempts < 5:
             try:
                 r = requests.get(endpoint, headers=headers, timeout=30)
+                if not r.ok:
+                    attempts += 1
+                    continue
+
                 secrets = json.loads(r.text)["SecretString"]
-            except requests.ConnectionError:
+            except (requests.ConnectionError, json.JSONDecodeError, ValueError):
                 attempts += 1
                 time.sleep(attempts * 0.5)
 


### PR DESCRIPTION
AWS Parameters and Secrets endpoint is used to retrieve/cache secrets when we invoke a lambda. 
Being an HTTP endpoint it may not always respond successfully. 

This PR adds some resilience to failures around seeding the env from the AWS endpoint:

- If we encounter a non 2xx response, make another attempt at retrieving secrets.
- If we encounter a successful response with unparseable JSON, make another attempt at retrieving secrets.