### PR TITLE
Ensure `oracle_client_libraries_layer_arn` comes from the environment config

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -29,6 +29,7 @@ module "lambdas" {
   healthcheck_lambda_role_arn                  = module.iam.healthcheck_lambda_role_arn
   callback_simulator_lambda_role_arn           = module.iam.callback_simulator_lambda_role_arn
   python_packages_layer_arn                    = module.lambda_layer.python_packages_layer_arn
+  oracle_client_libraries_layer_arn            = var.oracle_client_libraries_layer_arn
 }
 
 module "s3" {

--- a/terraform/modules/lambdas/variables.tf
+++ b/terraform/modules/lambdas/variables.tf
@@ -53,7 +53,6 @@ variable "parameters_and_secrets_lambda_extension_arn" {
 variable "oracle_client_libraries_layer_arn" {
   type        = string
   description = "ARN for the Oracle client libraries layer"
-  default     = "arn:aws:lambda:eu-west-2:730319765130:layer:bcss-comms-oracleclient:2"
 }
 
 variable "python_packages_layer_arn" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -28,6 +28,10 @@ variable "secrets_arn" {
   default = "arn:aws:secretsmanager:eu-west-2:123456789012:secret:bcss-nonprod-secrets-123456"
 }
 
+variable "oracle_client_libraries_layer_arn" {
+  type = string
+}
+
 variable "selected_vpc_id" {
   type = string
 }


### PR DESCRIPTION
Removes the default value and passes the ARN for the Oracle Client lambda layer from the environment config file.