### PR TITLE
Restructure to deploy to Native AWS Environment

### DIFF
--- a/.github/workflows/V2_deploy-lambda-oracleclient-layer.yml
+++ b/.github/workflows/V2_deploy-lambda-oracleclient-layer.yml
@@ -1,0 +1,52 @@
+name: Deploy BCSS Notify Oracle Lambda layer
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to deploy to'
+        required: true
+        default: 'preprod'
+        options:
+          - preprod
+          - prod
+jobs:
+  deploy-bcss-notify-oracleclient-lambda-layer:
+    name: "Deploy BCSS Notify Oracle Client lambda layer"
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Git clone the repository
+        uses: actions/checkout@v4
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-runner-role
+          aws-region: eu-west-2
+      - name: Install python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13' 
+      - name: Install zip tool
+        uses: montudor/action-zip@v1
+      - name: Fetch Oracle client libraries
+        run: |
+          curl --output oracli.zip "https://download.oracle.com/otn_software/linux/instantclient/2118000/instantclient-basiclite-linux.x64-21.18.0.0.0dbru.zip"
+      - name: Create Oracle client archive
+        run: |
+          mkdir python
+          mkdir lib
+          unzip -j oracli.zip -d lib
+          cp shared/libaio.so.1 lib/
+          zip -y -r oracleclient.zip python/ lib/
+      - name: Publish layer to AWS
+        run: |
+          aws lambda publish-layer-version \
+            --layer-name bcss-comms-oracleclient-${{ inputs.environment }} \
+            --zip-file fileb://oracleclient.zip \
+            --compatible-runtimes python3.13 \
+            --region eu-west-2

--- a/.github/workflows/V2_deploy-lambda-package-layer.yml
+++ b/.github/workflows/V2_deploy-lambda-package-layer.yml
@@ -1,0 +1,56 @@
+name: Deploy BCSS Notify Lambda Package Layer
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to deploy to'
+        required: true
+        default: 'preprod'
+        options:
+          - preprod
+          - prod
+jobs:
+  deploy-bcss-notify-lambda-layer:
+    name: "Deploy BCSS Notify lambda layers"
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Git clone the repository
+        uses: actions/checkout@v4
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-runner-role
+          aws-region: eu-west-2
+      - name: Install python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13' 
+      - name: Install zip tool
+        uses: montudor/action-zip@v1
+      - name: Create zip file for packages layer
+        run: |
+          pip install poetry
+          pip install poetry-plugin-export
+          mkdir -p python
+          poetry env use system
+          poetry export --without-hashes --format=requirements.txt > requirements.txt
+          poetry run pip install -r requirements.txt --target python/
+          cd python
+          find -name "tests" -type d | xargs rm -rf
+          find -name "__pycache__" -type d | xargs rm -rf
+          find -name "_pytest" -type d | xargs rm -rf
+          cd ..
+          zip -r layer.zip python/
+      - name: Publish layer to AWS
+        run: |
+          aws lambda publish-layer-version \
+            --layer-name bcss-comms-python-packages-${{ inputs.environment }} \
+            --zip-file fileb://layer.zip \
+            --compatible-runtimes python3.13 \
+            --region eu-west-2

--- a/.github/workflows/V2_deploy-lambdas.yml
+++ b/.github/workflows/V2_deploy-lambdas.yml
@@ -1,0 +1,68 @@
+name: "Deploy BCSS Notify Lambdas"
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to deploy to'
+        required: true
+        default: 'preprod'
+        options:
+          - preprod
+          - prod
+jobs:
+  deploy-bcss-notify-lambdas:
+    name: "Deploy BCSS Notify lambdas"
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }} || ${{ github.event_name == 'workflow_dispatch' }}
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Git clone the repository
+        uses: actions/checkout@v4
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-runner-role
+          aws-region: eu-west-2
+      - name: Install python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13' 
+      - name: Install zip tool
+        uses: montudor/action-zip@v1
+      - name: Create zip file for Batch Notification Processor function
+        run: cd batch_notification_processor && cp ../shared/*.py . && zip -r code.zip ./*.py
+      - name: Update Batch Notification Processor lambda function code
+        run: |
+          aws lambda update-function-code \
+            --function-name arn:aws:lambda:eu-west-2:${{ secrets.AWS_ACCOUNT_ID }}:function:bcss-comms-batch-notification-processor-${{ inputs.environment }} \
+            --zip-file fileb://batch_notification_processor/code.zip \
+            --region eu-west-2
+      - name: Create zip file for Message Status Handler function
+        run: cd message_status_handler && cp ../shared/*.py . && zip -r code.zip ./*.py
+      - name: Update Message Status Handler lambda function code
+        run: |
+          aws lambda update-function-code \
+            --function-name arn:aws:lambda:eu-west-2:${{ secrets.AWS_ACCOUNT_ID }}:function:bcss-comms-message-status-handler-${{ inputs.environment }} \
+            --zip-file fileb://message_status_handler/code.zip \
+            --region eu-west-2
+      - name: Create zip file for Healthcheck function
+        run: cd healthcheck && cp ../shared/*.py . && zip -r code.zip ./*.py
+      - name: Update Healthcheck lambda function code
+        run: |
+          aws lambda update-function-code \
+            --function-name arn:aws:lambda:eu-west-2:${{ secrets.AWS_ACCOUNT_ID }}:function:bcss-comms-healthcheck-${{ inputs.environment }} \
+            --zip-file fileb://healthcheck/code.zip \
+            --region eu-west-2
+      - name: Create zip file for Callback Simulator function
+        run: cd callback_simulator && cp ../shared/*.py . && zip -r code.zip ./*.py
+      - name: Update Callback Simulator lambda function code
+        run: |
+          aws lambda update-function-code \
+            --function-name arn:aws:lambda:eu-west-2:${{ secrets.AWS_ACCOUNT_ID }}:function:bcss-comms-callback-simulator-${{ inputs.environment }} \
+            --zip-file fileb://callback_simulator/code.zip \
+            --region eu-west-2

--- a/.github/workflows/V2_manual-terraform-action.yml
+++ b/.github/workflows/V2_manual-terraform-action.yml
@@ -1,0 +1,84 @@
+name: Manual Terraform Action
+run-name: Terraform ${{ inputs.action }} in ${{ inputs.environment }} for Notify Communication Management
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "The environment to deploy to"
+        required: true
+        type: choice
+        options:
+          - preprod
+          - prod
+      action:
+        description: "The Terraform action to perform"
+        required: true
+        type: choice
+        options:
+          - plan
+          - refresh
+          - apply
+          - destroy
+
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: eu-west-2
+  TF_BUCKET: bcss-${{ inputs.environment }}-terraform-state-store
+  TF_KEY: communication-management/terraform.tfstate
+
+jobs:
+  terraform-action:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    defaults:
+      run:
+        working-directory: ./terraform
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.12.2
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-runner-role
+
+      - name: Terraform Init
+        run: |
+          terraform init \
+            -backend-config="bucket=${{ env.TF_BUCKET }}" \
+            -backend-config="region=${{ env.AWS_REGION }}" \
+            -backend-config="key=${{ env.TF_KEY }}" \
+            -backend-config="use_lockfile=true"
+            
+         
+      - name: Terraform Action (${{ inputs.action }})
+        run: |
+          case "${{ inputs.action }}" in
+            plan)
+              terraform plan -var-file="./config/${{ inputs.environment }}.tfvars"
+              ;;
+            refresh)
+              terraform apply -refresh-only -var-file="./config/${{ inputs.environment }}.tfvars"
+              ;;
+            apply)
+              terraform apply -auto-approve -var-file="./config/${{ inputs.environment }}.tfvars"
+              ;;
+            destroy)
+              terraform destroy -auto-approve -var-file="./config/${{ inputs.environment }}.tfvars"
+              ;;
+            *)
+              echo "Invalid action specified. Use 'plan', 'apply', or 'destroy'."
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/V2_update-lambda-layer-versions.yml
+++ b/.github/workflows/V2_update-lambda-layer-versions.yml
@@ -1,0 +1,71 @@
+name: Update Notify Lambda Layer Versions
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to deploy to'
+        required: true
+        default: 'preprod'
+        options:
+          - preprod
+          - prod
+jobs:
+  update-notify-lambda-layer-versions:
+    name: "Deploy BCSS Notify lambda layers"
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Git clone the repository
+        uses: actions/checkout@v4
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-runner-role
+          aws-region: eu-west-2
+      - name: Get latest layer version ARNs for BCSS Notify Lambdas
+        id: get_latest_layer_version_arn
+        run: |
+          LATEST_LAYER_VERSION_ARN=$(aws lambda list-layer-versions \
+            --layer-name bcss-comms-python-packages-${{ inputs.environment }} \
+            --query 'LayerVersions[0].LayerVersionArn' \
+            --output text \
+            --region eu-west-2 \
+            | head -n 1)
+          ORACLE_CLIENT_LAYER_ARN=$(aws lambda list-layer-versions \
+            --layer-name bcss-comms-oracleclient-${{ inputs.environment }} \
+            --query 'LayerVersions[0].LayerVersionArn' \
+            --output text \
+            --region eu-west-2 \
+            | head -n 1)
+          echo "LATEST_LAYER_VERSION_ARN=$LATEST_LAYER_VERSION_ARN" >> $GITHUB_OUTPUT
+          echo "ORACLE_CLIENT_LAYER_ARN=$ORACLE_CLIENT_LAYER_ARN" >> $GITHUB_OUTPUT
+          echo "SECRETS_EXTENSION_ARN=arn:aws:lambda:eu-west-2:133256977650:layer:AWS-Parameters-and-Secrets-Lambda-Extension:12" >> $GITHUB_OUTPUT
+      - name: Update Batch Notification Processor lambda function configuration
+        run: |
+          aws lambda update-function-configuration \
+            --function-name arn:aws:lambda:eu-west-2:${{ secrets.AWS_ACCOUNT_ID }}:function:bcss-comms-batch-notification-processor-${{ inputs.environment }} \
+            --region eu-west-2 \
+            --layers ${{ steps.get_latest_layer_version_arn.outputs.LATEST_LAYER_VERSION_ARN }} ${{ steps.get_latest_layer_version_arn.outputs.ORACLE_CLIENT_LAYER_ARN }} ${{ steps.get_latest_layer_version_arn.outputs.SECRETS_EXTENSION_ARN }}
+      - name: Update Message Status Handler lambda function update-function-configuration
+        run: |
+          aws lambda update-function-configuration \
+            --function-name arn:aws:lambda:eu-west-2:${{ secrets.AWS_ACCOUNT_ID }}:function:bcss-comms-message-status-handler-${{ inputs.environment }} \
+            --region eu-west-2 \
+            --layers ${{ steps.get_latest_layer_version_arn.outputs.LATEST_LAYER_VERSION_ARN }} ${{ steps.get_latest_layer_version_arn.outputs.ORACLE_CLIENT_LAYER_ARN }} ${{ steps.get_latest_layer_version_arn.outputs.SECRETS_EXTENSION_ARN }}
+      - name: Update Healthcheck lambda function update-function-configuration
+        run: |
+          aws lambda update-function-configuration \
+            --function-name arn:aws:lambda:eu-west-2:${{ secrets.AWS_ACCOUNT_ID }}:function:bcss-comms-healthcheck-${{ inputs.environment }} \
+            --region eu-west-2 \
+            --layers ${{ steps.get_latest_layer_version_arn.outputs.LATEST_LAYER_VERSION_ARN }} ${{ steps.get_latest_layer_version_arn.outputs.ORACLE_CLIENT_LAYER_ARN }} ${{ steps.get_latest_layer_version_arn.outputs.SECRETS_EXTENSION_ARN }}
+      - name: Update Callback Simulator lambda function update-function-configuration
+        run: |
+          aws lambda update-function-configuration \
+            --function-name arn:aws:lambda:eu-west-2:${{ secrets.AWS_ACCOUNT_ID }}:function:bcss-comms-callback-simulator-${{ inputs.environment }} \
+            --region eu-west-2 \
+            --layers ${{ steps.get_latest_layer_version_arn.outputs.LATEST_LAYER_VERSION_ARN }} ${{ steps.get_latest_layer_version_arn.outputs.ORACLE_CLIENT_LAYER_ARN }} ${{ steps.get_latest_layer_version_arn.outputs.SECRETS_EXTENSION_ARN }}

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,6 +1,6 @@
 terraform {
   backend "s3" {
-    key    = "bcss/infrastructure/communication-management/terraform.tfstate"
+    key    = "communication-management/terraform.tfstate"
     region = "eu-west-2"
   }
 }

--- a/terraform/config/preprod.config
+++ b/terraform/config/preprod.config
@@ -1,0 +1,1 @@
+bucket         = "bcss-preprod-terraform-state-store"

--- a/terraform/config/preprod.tfvars
+++ b/terraform/config/preprod.tfvars
@@ -1,0 +1,14 @@
+environment = "preprod"
+team        = "bcss"
+project     = "comms"
+region      = "eu-west-2"
+
+kms_arn     = "arn:aws:kms:eu-west-2:784733659476:key/d433aa67-598b-4fdb-806b-3e1f4738bdc4"
+secrets_arn = "arn:aws:secretsmanager:eu-west-2:784733659476:secret:bcss-preprod-oracle-preprod-notify-lambdas-secret-eZ0OhP"
+
+selected_vpc_id = "vpc-0a409ba281f33e2e3"
+
+tags = {
+  "Service" = "bcss"
+}
+

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -29,7 +29,7 @@ module "lambdas" {
   healthcheck_lambda_role_arn                  = module.iam.healthcheck_lambda_role_arn
   callback_simulator_lambda_role_arn           = module.iam.callback_simulator_lambda_role_arn
   python_packages_layer_arn                    = module.lambda_layer.python_packages_layer_arn
-  oracle_client_libraries_layer_arn            = var.oracle_client_libraries_layer_arn
+  oracle_client_libraries_layer_arn            = module.lambda_layer.oracle_client_libraries_layer_arn
 }
 
 module "s3" {

--- a/terraform/modules/lambda_layer/main.tf
+++ b/terraform/modules/lambda_layer/main.tf
@@ -17,3 +17,9 @@ resource "aws_lambda_layer_version" "python_packages" {
   compatible_runtimes = [local.runtime]
   filename            = "${path.module}/placeholder.zip"
 }
+
+resource "aws_lambda_layer_version" "oracle_client_libraries" {
+  layer_name          = "${var.team}-${var.project}-oracleclient-${var.environment}"
+  compatible_runtimes = [local.runtime]
+  filename            = "${path.module}/placeholder.zip"
+}

--- a/terraform/modules/lambda_layer/outputs.tf
+++ b/terraform/modules/lambda_layer/outputs.tf
@@ -1,3 +1,7 @@
 output "python_packages_layer_arn" {
   value = aws_lambda_layer_version.python_packages.arn
 }
+
+output "oracle_client_libraries_layer_arn" {
+  value = aws_lambda_layer_version.oracle_client_libraries.arn
+}

--- a/terraform/modules/network/main.tf
+++ b/terraform/modules/network/main.tf
@@ -2,6 +2,9 @@ data "aws_vpc" "selected" {
   id = var.selected_vpc_id
 }
 
+# Important note:
+# The DB requires connection only from private-a subnet.
+# This is because the DB is only available in AZ 2a
 data "aws_subnets" "private" {
   filter {
     name   = "vpc-id"
@@ -9,7 +12,7 @@ data "aws_subnets" "private" {
   }
 
   tags = {
-    "Name" = "*private*"
+    "Name" = "*private-a*"
   }
 }
 

--- a/terraform/modules/network/main.tf
+++ b/terraform/modules/network/main.tf
@@ -1,5 +1,5 @@
 data "aws_vpc" "selected" {
-  id = "vpc-0a409ba281f33e2e3"
+  id = var.selected_vpc_id
 }
 
 data "aws_subnets" "private" {
@@ -16,4 +16,3 @@ data "aws_subnets" "private" {
 data "aws_security_group" "lambda" {
   name = "bcss-notify-lambdas"
 }
-

--- a/terraform/modules/network/main.tf
+++ b/terraform/modules/network/main.tf
@@ -1,5 +1,5 @@
 data "aws_vpc" "selected" {
-  id = "vpc-09c7c54244a87b9d9"
+  id = "vpc-0a409ba281f33e2e3"
 }
 
 data "aws_subnets" "private" {

--- a/terraform/modules/network/outputs.tf
+++ b/terraform/modules/network/outputs.tf
@@ -5,5 +5,5 @@ output "private_subnet_ids" {
 
 output "security_group" {
   value       = data.aws_security_group.lambda.id
-  description = "List of private subnet IDs"
+  description = "Security Group ID"
 }


### PR DESCRIPTION
**Warning - should not be merged until after work has concluded in Texas**

This PR does a number of things - 

- New 'version 2' pipelines to deploy lambdas, layers and terraform into segmented environments (environment specific vars have been added to the settings tab of this repo to facilitate this)
- Changes to terraform to target the new AWS account (data blocks, new tfvars, etc)
- Build oracle layer arn as placeholder to align with the way the package layer is built