### PR TITLE
Reverted change to remove columns from SELECT query

### DIFF
--- a/batch_notification_processor/oracle_database.py
+++ b/batch_notification_processor/oracle_database.py
@@ -31,6 +31,9 @@ def get_recipients(batch_id: str) -> list[Recipient]:
                 """
                 SELECT nhs_number,
                        message_id,
+                       batch_id,
+                       routing_plan_id,
+                       message_status,
                        address_line_1,
                        address_line_2,
                        address_line_3,

--- a/tests/unit/batch_notification_processor/test_oracle_database.py
+++ b/tests/unit/batch_notification_processor/test_oracle_database.py
@@ -56,6 +56,9 @@ def test_get_recipients(mock_database):
         """
                 SELECT nhs_number,
                        message_id,
+                       batch_id,
+                       routing_plan_id,
+                       message_status,
                        address_line_1,
                        address_line_2,
                        address_line_3,


### PR DESCRIPTION
I undid the change that removes 3 columns (batch_id, routing_plan_id, message_status) from the select query to get recipients from the queue table